### PR TITLE
fix bug: hddLBA should be 32-bit

### DIFF
--- a/bsect.asm
+++ b/bsect.asm
@@ -259,7 +259,7 @@ gdt_end:
     cmdLine db cmdLineDef,0
     cmdLineLen equ $-cmdLine
     initRdSize dd initRdSizeDef ; from config.inc
-    hddLBA dw 1   ; start address for kernel - subsequent calls are sequential
+    hddLBA dd 1   ; start address for kernel - subsequent calls are sequential
 
 ;boot sector magic
 	times	510-($-$$)	db	0


### PR DESCRIPTION
Was debugging this with `bochs` and noticed that I was getting unusual values after loading `hddLBA` into `edx`.  `hddLBA` is used as disk sector "counter" variable of which 32-bits are used, but only 2 bytes were allocated to it (using `dw` instead of `dd`).  This is the last variable defined so it is normally followed by a bunch of zeros which means you'd be fine.  However, if it gets moved or a non-zero value gets positioned after it (which is what I had done) then it will manifest the bug.